### PR TITLE
Fix undefined index when quering groups in LDAP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 All notable changes to this project will be documented in this file.
+
+ ## [Unreleased]
+ [Fixed]
+ - Fix undefined index when quering groups in LDAP
  
  ## [rciam-2.2.0] - 2019-12-06
  [Changed]

--- a/lib/AdapterLdap.php
+++ b/lib/AdapterLdap.php
@@ -258,7 +258,16 @@ class sspmod_perun_AdapterLdap extends sspmod_perun_Adapter
 		);
 
 		foreach ($groups as $group) {
-			array_push($resultGroups, new sspmod_perun_model_Group($group['perunGroupId'][0], $group['perunVoId'][0], $group['cn'][0], $group['perunUniqueGroupName'][0], $group['description'][0]));
+			array_push(
+				$resultGroups,
+				new sspmod_perun_model_Group(
+					(empty($group['perunGroupId'][0]) ? "" : $group['perunGroupId'][0]),
+					(empty($group['perunVoId'][0]) ? "" : $group['perunVoId'][0]),
+					(empty($group['cn'][0]) ? "" : $group['cn'][0]),
+					(empty($group['perunUniqueGroupName'][0]) ? "" : $group['perunUniqueGroupName'][0]),
+					(empty($group['description'][0]) ? "" : $group['description'][0])
+				)
+			);
 		}
 		$resultGroups = $this->removeDuplicateEntities($resultGroups);
 		SimpleSAML_Logger::debug("Groups - ".var_export($resultGroups, true));

--- a/lib/Auth/Process/PerunIdentity.php
+++ b/lib/Auth/Process/PerunIdentity.php
@@ -189,7 +189,7 @@ class sspmod_perun_Auth_Process_PerunIdentity extends SimpleSAML_Auth_Processing
 		$tempGroups = $this->adapter->getUsersGroupsOnFacility($this->spEntityId, $user->getId());
 		$groups = array();
 		foreach ($tempGroups as $group) {
-			if (is_null($group->getId())) {
+			if (empty($group->getId())) {
 				$vo = $this->adapter->getVoById($group->getVoId());
 				if (!empty($vo)) {
 					array_push($groups, new sspmod_perun_model_Group($group->getVoId(), $group->getVoId(), $vo->getShortName(), $vo->getShortName(), $group->getDescription()));


### PR DESCRIPTION
When searching for groups in LDAP, and there are VOs in the response of the query, then some variables of the Group object will be empty because the Group and Vo model are different and not match one-to-one.